### PR TITLE
Fix typo in toast messages

### DIFF
--- a/src/components/(pages)/CreatePost/index.jsx
+++ b/src/components/(pages)/CreatePost/index.jsx
@@ -42,7 +42,7 @@ const CreatePost = () => {
         toast.success("Image Generated");
       }
     } catch (err) {
-      toast.error("An error has apper");
+      toast.error("An error has appeared");
       console.error(err);
     } finally {
       setGeneratingImg(false);

--- a/src/components/(pages)/Home/index.jsx
+++ b/src/components/(pages)/Home/index.jsx
@@ -20,7 +20,7 @@ const Home = () => {
       }
     } catch (err) {
       console.log(err);
-      toast.error("An error has apper");
+      toast.error("An error has appeared");
       setLoading(false);
       return;
     }


### PR DESCRIPTION
## Summary
- correct typo in Home and CreatePost error notifications

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6840a1ca5838832a893f0e2f47b2511d